### PR TITLE
Changes front for deploy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,17 +4,21 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { Provider } from 'react-redux';
 import store from './redux/store';
+import axios from 'axios';
+import dotenv from 'dotenv';
+dotenv.config();
+
+axios.defaults.baseURL = process.env.REACT_APP_API || "http://localhost:4000"
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <Provider store={store}>
-      
-        <App />
-     
+      <App />
     </Provider>
   </React.StrictMode>
 );
+
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -1,11 +1,14 @@
-//import axios from 'axios'
+import axios from 'axios'
 
-// export function getAllInstruments(){
-//     return async function(dispatch){
-//         const resu =  await axios('/instruments')
-//         dispatch({
-//             type: "GET_ALL_INSTRUMENTS",
-//             payload: resu.data
-//         })
-//     }
-// }
+export const GET_ALL_PRODUCTS = "GET_ALL_PRODUCTS";
+
+export const getAllProducts = () => {
+    return async function (dispatch) {
+        const products = await axios('/products');
+
+        return dispatch({
+            type: GET_ALL_PRODUCTS,
+            payload: products.data
+        });
+    };
+};

--- a/src/redux/reducer/index.js
+++ b/src/redux/reducer/index.js
@@ -1,3 +1,7 @@
+const {
+    GET_ALL_PRODUCTS
+} = require('../actions/index');
+
 const initialState = {
     instruments: [],
     allInstruments:[]
@@ -5,7 +9,13 @@ const initialState = {
 
 export default function rootReducer(state = initialState, action){
     switch(action.type){
-        
+        case GET_ALL_PRODUCTS:
+            return {
+                ...state,
+                allInstruments: action.payload,
+                instruments: action.payload,    
+            }
+
         default: 
         return state
     }


### PR DESCRIPTION
Cuando se hace el deploy las rutas del back no empezaran con localhost, por este motivo se le indica al axios en el front que si esta siendo hosteado las rutas las tome de aquellas que le indique la propia pagina, de otra manera, si esta siento usada localmente, ahí si tome el localhost:4000